### PR TITLE
Rename ImGuiKey_KeyPadEnter to ImGuiKey_KeypadEnter

### DIFF
--- a/rpn_calculator_app.cpp
+++ b/rpn_calculator_app.cpp
@@ -345,7 +345,7 @@ void HandleComputerKeyboard(CalculatorState& calculatorState)
     }
     if (ImGui::IsKeyPressed(ImGuiKey_Backspace))
         calculatorState.OnComputerKey('\b');
-    if (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeyPadEnter))
+    if (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))
         calculatorState.OnComputerKey('\n');
 }
 


### PR DESCRIPTION
Fixes compilation error with dear imgui, v1.91.5:

> error: use of undeclared identifier 'ImGuiKey_KeyPadEnter'; did you mean 'ImGuiKey_KeypadEnter'?

The method name was changed in v1.90.1
https://github.com/ocornut/imgui/releases/tag/v1.90.1


<img width="1082" alt="Screenshot 2024-12-18 at 20 21 15" src="https://github.com/user-attachments/assets/6cc06cd7-b338-4104-8763-41867a778362" />

<img width="1082" alt="Screenshot 2024-12-18 at 20 22 23" src="https://github.com/user-attachments/assets/70bf6339-e628-4475-92bc-c467b190c003" />


